### PR TITLE
New faces

### DIFF
--- a/color-theme-sanityinc-solarized.el
+++ b/color-theme-sanityinc-solarized.el
@@ -194,6 +194,12 @@
          (diff-file-header ((t (:foreground ,blue :background nil))))
          (diff-hunk-header ((t (:foreground ,magenta))))
 
+	 ;; undo-tree
+	 (undo-tree-visualizer-default-face ((t (:foreground ,normal))))
+	 (undo-tree-visualizer-current-face ((t (:foreground ,green :weight bold))))
+	 (undo-tree-visualizer-active-branch-face ((t (:foreground ,red))))
+	 (undo-tree-visualizer-register-face ((t (:foreground ,yellow))))
+
          ;; dired+
          (diredp-dir-heading ((t (:foreground nil :background nil :inherit heading))))
          (diredp-dir-priv ((t (:foreground ,cyan :background nil))))


### PR DESCRIPTION
The most useful are the changes for ansi-color, as those are used for all modes that render ANSI color escapes from shells, debuggers, etc.

The others are for rhtml-mode, undo-tree and parenface.

Thanks for doing the color-space tweaks for Emacs under OS X - much appreciated!  I've been using this for months now and love it.
