### PR TITLE
Use background instead of alt-background for fringe

### DIFF
--- a/color-theme-sanityinc-solarized.el
+++ b/color-theme-sanityinc-solarized.el
@@ -281,7 +281,7 @@ names to which it refers are bound."
 
       ;; Emacs interface
       (cursor (:background ,magenta))
-      (fringe (:background ,alt-background :foreground ,faintest))
+      (fringe (:background ,background :foreground ,faintest))
       (linum (:background ,alt-background :foreground ,faintest :italic nil :underline nil))
       (line-number (:background ,alt-background :foreground ,faintest))
       (line-number-current-line (:inherit line-number :foreground ,normal :weight bold))


### PR DESCRIPTION
[Fringe] Use background instead of alt-background to avoid the fringe when the content is centered (e.g. olivetti-mode or visual-fill-column)

![image](https://i.ibb.co/bRZ64xf/fringe.jpg)