### PR TITLE
Add support for tab-line and window-tool-bar

### DIFF
--- a/color-theme-sanityinc-solarized.el
+++ b/color-theme-sanityinc-solarized.el
@@ -776,6 +776,16 @@ names to which it refers are bound."
       (tab-line-tab-current (:inherit tab-line-tab :foreground ,background :background ,normal))
       (tab-line-tab-inactive-alternate (:inherit tab-line-tab-inactive))
       (tab-line-tab-modified (:weight bold))
+
+      ;; window-tool-bar
+      (window-tool-bar-button (:inherit tab-line
+                                        :foreground ,normal :background ,background
+                                        :box (:line-width 1 :color ,normal :style released-button)))
+      (window-tool-bar-button-hover (:inherit window-tool-bar-button
+                                              :foreground ,background :background ,normal))
+      (window-tool-bar-button-disabled (:inherit window-tool-bar-button
+                                                 :foreground ,faint :background ,alt-background
+                                                 :box (:line-width 1 :color ,faint :style released-button)))
       ))))
 
 (defmacro color-theme-sanityinc-solarized--frame-parameter-specs ()

--- a/color-theme-sanityinc-solarized.el
+++ b/color-theme-sanityinc-solarized.el
@@ -764,6 +764,18 @@ names to which it refers are bound."
       (term-color-magenta (:foreground ,magenta :background ,magenta))
       (term-color-cyan    (:foreground ,cyan :background ,cyan))
       (term-color-white   (:foreground ,background :background ,background))
+
+      ;; tab-line
+      (tab-line (:inherit variable-pitch
+                          :foreground ,faintest :background ,alt-background))
+      (tab-line-tab (:foreground ,background :background ,faint
+                                 :box (:line-width 1 :color ,normal :style released-button)))
+      (tab-line-tab-inactive (:inherit tab-line-tab :foreground ,faint :background ,background
+                                       :box (:line-width 1 :color ,faint :style released-button)))
+      (tab-line-highlight (:foreground ,background :background ,normal))
+      (tab-line-tab-current (:inherit tab-line-tab :foreground ,background :background ,normal))
+      (tab-line-tab-inactive-alternate (:inherit tab-line-tab-inactive))
+      (tab-line-tab-modified (:weight bold))
       ))))
 
 (defmacro color-theme-sanityinc-solarized--frame-parameter-specs ()


### PR DESCRIPTION
This adds support for two built in modes, `tab-line-mode` and `window-tool-bar-mode`. This should look familiar, as it is similar to https://github.com/purcell/color-theme-sanityinc-tomorrow/pull/173.

I would have liked to do this with the same logic as https://github.com/bbatsov/solarized-emacs/pull/452, but the meaning of the `baseXX` colors is very different in this repository, so I instead recreated a styling from scratch.